### PR TITLE
feat(migrations): configurer Alembic pour les migrations

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,84 @@
+# Alembic Configuration File
+# For Church Team Management Backend
+
+[alembic]
+# Path to migration scripts
+script_location = migrations
+
+# Template used for generating new revision files
+# file_template = %%(rev)s_%%(slug)s
+
+# Prepend system path for imports
+prepend_sys_path = .
+
+# Timezone for the revision creation date
+# timezone = UTC
+
+# Max length of characters for auto-generated slug
+# truncate_slug_length = 40
+
+# Set to 'true' to run the environment during revision scripts
+# generation
+# revision_environment = false
+
+# Set to 'true' to allow .pyc and .pyo files without source .py files
+# sourceless = false
+
+# Version location specification
+# version_locations = %(here)s/bar:%(here)s/bat:%(here)s/migrations/versions
+
+# Version path separator
+# version_path_separator = os
+
+# Output encoding for revision files
+# output_encoding = utf-8
+
+# Database URL is loaded dynamically from environment variables in env.py
+# This placeholder is overridden at runtime
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+# Post write hooks - format generated migration files
+[post_write_hooks]
+# Run ruff format on newly generated files
+hooks = ruff
+
+ruff.type = exec
+ruff.executable = ruff
+ruff.options = format REVISION_SCRIPT_FILENAME
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,0 +1,148 @@
+"""
+Alembic Environment Configuration.
+
+This module configures Alembic for async SQLAlchemy with PostgreSQL.
+It supports both offline (SQL generation) and online (database connection) modes.
+
+The database URL is loaded from environment variables via the app configuration,
+ensuring consistency with the main application.
+"""
+
+import asyncio
+import os
+from logging.config import fileConfig
+
+from dotenv import load_dotenv
+from sqlalchemy import pool
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+from alembic import context
+
+# Load environment variables from .env file
+# This ensures DATABASE_URL and other required vars are available
+# interpolate=True enables ${VAR} substitution
+load_dotenv(interpolate=True)
+
+# Import the settings to get database URL from environment
+from app.core.config import settings
+
+# Import Base to access metadata for autogenerate support
+from app.core.database import Base
+
+# Import all models here so they are registered with Base.metadata
+# This ensures Alembic can detect all tables for autogenerate
+# Example:
+# from app.models.user import User
+# from app.models.organization import Organization
+
+# Alembic Config object
+config = context.config
+
+# Override sqlalchemy.url with the actual database URL from settings
+# Convert asyncpg URL to standard postgresql for offline mode compatibility
+database_url = str(settings.database_url)
+config.set_main_option("sqlalchemy.url", database_url)
+
+# Configure Python logging from the config file
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Target metadata for autogenerate support
+# This is the MetaData object from your declarative base
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """
+    Run migrations in 'offline' mode.
+
+    This configures the context with just a URL and not an Engine.
+    Calls to context.execute() emit the given string to the script output.
+
+    This is useful for generating SQL scripts without a database connection.
+    """
+    url = config.get_main_option("sqlalchemy.url")
+
+    # For offline mode, we need to convert async URL to sync format
+    if url and url.startswith("postgresql+asyncpg://"):
+        url = url.replace("postgresql+asyncpg://", "postgresql://")
+
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        compare_type=True,
+        compare_server_default=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection) -> None:
+    """
+    Execute migrations using the provided connection.
+
+    This function is run synchronously within the async context.
+
+    Args:
+        connection: SQLAlchemy database connection
+    """
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        compare_type=True,
+        compare_server_default=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_async_migrations() -> None:
+    """
+    Run migrations in 'online' mode with async engine.
+
+    Creates an async Engine and associates a connection with the context.
+    The connection is used to run all migrations within a transaction.
+    """
+    # Create async engine configuration
+    configuration = config.get_section(config.config_ini_section) or {}
+
+    # Ensure we use the async driver
+    if "sqlalchemy.url" in configuration:
+        url = configuration["sqlalchemy.url"]
+        # Ensure async URL format
+        if url.startswith("postgresql://"):
+            configuration["sqlalchemy.url"] = url.replace(
+                "postgresql://", "postgresql+asyncpg://"
+            )
+
+    connectable = async_engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+
+    await connectable.dispose()
+
+
+def run_migrations_online() -> None:
+    """
+    Run migrations in 'online' mode.
+
+    This is the entry point for online migrations.
+    It delegates to the async migration runner.
+    """
+    asyncio.run(run_async_migrations())
+
+
+# Determine which mode to run in based on context
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/migrations/script.py.mako
+++ b/backend/migrations/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade database schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade database schema."""
+    ${downgrades if downgrades else "pass"}

--- a/backend/migrations/versions/.gitkeep
+++ b/backend/migrations/versions/.gitkeep
@@ -1,1 +1,0 @@
-# Alembic migration versions

--- a/backend/migrations/versions/b0c7bfbf8937_initial_setup.py
+++ b/backend/migrations/versions/b0c7bfbf8937_initial_setup.py
@@ -1,0 +1,28 @@
+"""initial_setup
+
+Revision ID: b0c7bfbf8937
+Revises:
+Create Date: 2025-12-27 13:36:45.621651
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b0c7bfbf8937'
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade database schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade database schema."""
+    pass

--- a/specs/001-church-team-management/tasks.md
+++ b/specs/001-church-team-management/tasks.md
@@ -53,7 +53,7 @@ Ce document contient toutes les tâches d'implémentation dérivées des 10 user
   ```
 - [x] **T0.2.3** Configurer `app/core/config.py` avec Pydantic Settings
 - [x] **T0.2.4** Configurer SQLAlchemy 2.0 async avec `app/core/database.py`
-- [ ] **T0.2.5** Configurer Alembic pour les migrations
+- [x] **T0.2.5** Configurer Alembic pour les migrations
 - [ ] **T0.2.6** Créer le fichier `app/main.py` avec CORS et middleware
 - [ ] **T0.2.7** Configurer logging JSON structuré avec correlation_id
 


### PR DESCRIPTION
Ajout de la configuration d'Alembic pour gérer les migrations de la base de données avec un support pour SQLAlchemy asynchrone. Création des fichiers de configuration nécessaires et des scripts de migration initiaux.

Supprime le fichier .gitkeep dans le répertoire des versions.